### PR TITLE
[RIGS-86-fix] fix duplicated logging

### DIFF
--- a/etl/tools/main.py
+++ b/etl/tools/main.py
@@ -1,4 +1,5 @@
 """Main program to run the ETL"""
+import logging
 import os
 import traceback
 from argparse import ArgumentParser
@@ -17,7 +18,7 @@ from etl.util.db import (
 )
 from etl.util.exceptions import DBConnectionException
 from etl.util.files import load_config_from_file
-from etl.util.logger import setup_logger
+from etl.util.logger import set_logger_verbosity
 
 DESCRIPTION: Final[str] = "Execute the Rigshospitalet ETL."
 
@@ -66,7 +67,9 @@ def main() -> None:
 
     cnxn = get_connection_details(load_config_from_file(conn_file))
 
-    logger = setup_logger(verbosity)
+    logger = logging.getLogger("ETL")
+    set_logger_verbosity(logger, verbosity)
+
     logger.info("Connecting to database...")
     engine = None
     if cnxn.dbms == "postgresql":

--- a/etl/util/db.py
+++ b/etl/util/db.py
@@ -18,7 +18,7 @@ from etl.util.logger import setup_logger
 from .connection import ConnectionDetails
 from .exceptions import DependencyNotFoundException
 
-logger = setup_logger("info")
+logger = setup_logger("ENVIRONMENT")
 
 
 class AbstractSession(ABC):

--- a/etl/util/logger.py
+++ b/etl/util/logger.py
@@ -77,6 +77,19 @@ class Logger:
             return pd.DataFrame()
 
 
+def set_logger_verbosity(logger: logging.Logger, verbosity_level: str) -> None:
+    log_levels = {
+        "DEBUG": logging.DEBUG,
+        "WARNING": logging.WARNING,
+        "ERROR": logging.ERROR,
+    }
+    logger.setLevel(
+        log_levels[verbosity_level]
+        if verbosity_level in log_levels
+        else logging.INFO
+    )
+
+
 def setup_logger(verbosity_level: str) -> logging.Logger:
     logdir = "../log"
     if not os.path.exists(logdir):
@@ -95,17 +108,8 @@ def setup_logger(verbosity_level: str) -> logging.Logger:
     c_handler.setFormatter(l_format)
     f_handler.setFormatter(l_format)
 
-    log_levels = {
-        "DEBUG": logging.DEBUG,
-        "WARNING": logging.WARNING,
-        "ERROR": logging.ERROR,
-    }
-    c_handler.setLevel(
-        log_levels[verbosity_level]
-        if verbosity_level in log_levels
-        else logging.INFO
-    )
-    f_handler.setLevel(logging.DEBUG)
+    set_logger_verbosity(c_handler, verbosity_level)
+    set_logger_verbosity(f_handler, "DEBUG")
 
     logger.addHandler(c_handler)
     logger.addHandler(f_handler)


### PR DESCRIPTION
Logging is a bit tricky. with your solution we had two loggers printing at the same time. I have tried to fix it keeping also verbosity working. At the moment it works except one thing - the warning coming from the env variables is printed regardless of the verbosity 