### PR TITLE
Run condition eras in batches

### DIFF
--- a/etl/transform/condition_era.py
+++ b/etl/transform/condition_era.py
@@ -5,7 +5,10 @@ import logging
 from ..models.omopcdm54.standardized_derived_elements import (
     ConditionEra as OmopConditionEra,
 )
-from ..sql.condition_era import get_condition_era_insert
+from ..sql.condition_era import (
+    get_condition_era_insert,
+    get_conditions_with_data,
+)
 from ..util.db import AbstractSession
 
 logger = logging.getLogger("ETL.ConditionEra")
@@ -14,7 +17,12 @@ logger = logging.getLogger("ETL.ConditionEra")
 def transform(session: AbstractSession) -> None:
     """Run the Condition era transformation"""
     logger.info("Starting the condition era transformation... ")
-    session.execute(get_condition_era_insert(session))
+
+    chunked_concept_ids = get_conditions_with_data(session)
+    for chunk in chunked_concept_ids:
+        logger.debug("  Processing condition era for concept IDs %s...", chunk)
+        session.execute(get_condition_era_insert(session, chunk))
+
     logger.info(
         "Condition era Transformation complete! %s rows included",
         session.query(OmopConditionEra).count(),

--- a/tests/transform/condition_era_tests.py
+++ b/tests/transform/condition_era_tests.py
@@ -7,7 +7,6 @@ from etl.models.omopcdm54.clinical import Stem as OmopStem
 from etl.models.omopcdm54.standardized_derived_elements import (
     ConditionEra as OmopConditionEra,
 )
-from etl.models.omopcdm54.vocabulary import Concept, ConceptAncestor
 from etl.transform.condition_era import (
     transform as condition_era_transformation,
 )


### PR DESCRIPTION
Fixes #79. Wanted to use `itertools.batched` in `get_conditions_with_data()`, but that's unavailable in the Python version we use.