### PR TITLE
Validate era_lookback_intervals

### DIFF
--- a/etl/process.py
+++ b/etl/process.py
@@ -75,6 +75,7 @@ from .util.logger import ErrorHandler
 from .util.preprocessing import (
     validate_concept_ids,
     validate_domain_ids,
+    validate_era_lookback_intervals,
     validate_timezones,
 )
 
@@ -173,6 +174,10 @@ def run_etl(
         lookup_loader.data.get(ConceptLookupStem.__tablename__),
         session,
         "timezone",
+    )
+    validate_era_lookback_intervals(
+        lookup_loader.data.get(ConceptLookupStem.__tablename__),
+        "era_lookback_interval",
     )
 
     create_lookup_tables(session, lookup_loader.data)

--- a/etl/sql/stem/insert_drugs_into_stem.py
+++ b/etl/sql/stem/insert_drugs_into_stem.py
@@ -3,6 +3,7 @@
 import os
 from typing import Any, Final
 
+import pandas as pd
 from sqlalchemy import (
     DATE,
     FLOAT,
@@ -44,7 +45,7 @@ from .utils import (
 CONCEPT_ID_EHR: Final[int] = 32817
 INCLUDE_UNMAPPED_CODES = os.getenv("INCLUDE_UNMAPPED_CODES", "TRUE") == "TRUE"
 DEFAULT_ERA_LOOKBACK_INTERVAL = get_environment_variable(
-    "DRUG_ERA_LOOKBACK", "24 hours"
+    "DRUG_ERA_LOOKBACK", "24 hours", pd.to_timedelta
 )
 
 

--- a/etl/sql/stem/insert_registries_into_stem.py
+++ b/etl/sql/stem/insert_registries_into_stem.py
@@ -3,6 +3,7 @@
 import os
 from typing import Any, Final
 
+import pandas as pd
 from sqlalchemy import (
     DATE,
     INT,
@@ -31,7 +32,7 @@ from .utils import (
 
 REGISTRY_TIMEZONE: Final[str] = "Europe/Copenhagen"
 DEFAULT_ERA_LOOKBACK_INTERVAL = get_era_lookback_interval(
-    "CONDITION_ERA_LOOKBACK", "30 days"
+    "CONDITION_ERA_LOOKBACK", "30 days", pd.to_timedelta
 )
 
 

--- a/etl/util/db.py
+++ b/etl/util/db.py
@@ -231,15 +231,15 @@ def make_engine_duckdb(connection: ConnectionDetails, **kwargs) -> Engine:
 def get_environment_variable(
     environment_variable_name: str = None, default: str = None
 ) -> str:
-    schema_name: str = os.getenv(environment_variable_name, default=None)
-    if not schema_name:
+    value: str = os.getenv(environment_variable_name, default=None)
+    if not value:
         logger.debug(
             "Environment variable %s not set, defaults to '%s'",
             environment_variable_name,
             default,
         )
-        schema_name = default
-    return schema_name
+        value = default
+    return value
 
 
 class WriteMode(Enum):

--- a/etl/util/db.py
+++ b/etl/util/db.py
@@ -233,6 +233,12 @@ def get_environment_variable(
     default: str = None,
     validator: Callable = None,
 ) -> str:
+    """
+    Get the value of an environment variable, falling back to a default (if given) or None (otherwise).
+    Optionally, one ca provide a function validator, which should raise a ValueError if the value
+    doesn't conform to the desired format.
+    """
+
     value: str = os.getenv(environment_variable_name, default=None)
     if not value:
         logger.debug(

--- a/etl/util/db.py
+++ b/etl/util/db.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from enum import Enum
 from tempfile import NamedTemporaryFile
-from typing import Any, Generator, Iterable, List, Literal, Optional
+from typing import Any, Callable, Generator, Iterable, List, Literal, Optional
 
 import pandas as pd
 from sqlalchemy import JSON, create_engine, inspect
@@ -229,7 +229,9 @@ def make_engine_duckdb(connection: ConnectionDetails, **kwargs) -> Engine:
 
 
 def get_environment_variable(
-    environment_variable_name: str = None, default: str = None
+    environment_variable_name: str = None,
+    default: str = None,
+    validator: Callable = None,
 ) -> str:
     value: str = os.getenv(environment_variable_name, default=None)
     if not value:
@@ -239,6 +241,19 @@ def get_environment_variable(
             default,
         )
         value = default
+
+    if validator:
+        try:
+            validator(value)
+        except ValueError:
+            logger.warning(
+                "Invalid value '%s' given for environment variable %s, defaults to '%s'",
+                value,
+                environment_variable_name,
+                default,
+            )
+            value = default
+
     return value
 
 

--- a/etl/util/preprocessing.py
+++ b/etl/util/preprocessing.py
@@ -94,10 +94,24 @@ def validate_timezones(
     provided_tz = set(tz for tz in original_tz if not pd.isna(tz))
 
     for invalid_tz in provided_tz - allowed_tz:
-        logger.debug(
-            """Time zone %s invalid. It has been set to NULL.""", invalid_tz
-        )
+        logger.debug("Invalid time zone '%s' replaced by NULL.", invalid_tz)
 
     new_tz = [str(tz) if tz in allowed_tz else None for tz in original_tz]
     input_df[timezone_column] = new_tz
+    return input_df
+
+
+def validate_era_lookback_intervals(
+    input_df: pd.DataFrame, era_lookback_interval_column: str
+) -> pd.DataFrame:
+    for era in set(input_df[era_lookback_interval_column]):
+        try:
+            pd.to_timedelta(era)
+        except ValueError:
+            logger.debug(
+                "Invalid era_lookback_interval '%s' replaced by NULL", era
+            )
+            replace_idx = input_df[era_lookback_interval_column] == era
+            input_df.loc[replace_idx, era_lookback_interval_column] = None
+
     return input_df


### PR DESCRIPTION
This somehow fell out of #149, so now it gets its own PR. Valid era_lookback_intervals in concept_lookup_stem are crucial for the eras, so with this we validate those given by the user.